### PR TITLE
Use new --no-cache option for apk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM edib/base-alpine:3.3
 MAINTAINER Christoph Grabo <edib@markentier.com>
 
-RUN apk --update add \
+RUN apk --no-cache add \
     bash binutils-gold ca-certificates clang cmake curl \
     file gawk gcc g++ git libc-dev libgcc \
-    llvm llvm-libs make openssh python rsync vim wget zsh && \
-    rm -rf /var/cache/apk/*
+    llvm llvm-libs make openssh python rsync vim wget zsh


### PR DESCRIPTION
As of Alpine Linux 3.3 there exists a new --no-cache option for apk. It allows users to install packages with an index that is updated and used on-the-fly and not cached locally.

https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache
